### PR TITLE
[Add] sessionid headers

### DIFF
--- a/dev.envoy.yaml
+++ b/dev.envoy.yaml
@@ -30,7 +30,7 @@ static_resources:
                         allow_origin_string_match:
                           - prefix: "*"
                         allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,sessionid
                         max_age: "1728000"
                         expose_headers: custom-header-1,grpc-status,grpc-message
                 http_filters:


### PR DESCRIPTION
this pr adds **sessionid** to the list of allowed headers to avoid cors error in preflight request to the proxy.

seesionid header is to send metadata with grpc request for authentication.